### PR TITLE
chore: Wait for draft release to appear before resolving

### DIFF
--- a/src/github-repo.spec.ts
+++ b/src/github-repo.spec.ts
@@ -186,7 +186,10 @@ describe('GithubRepo', () => {
     });
 
     it('creates a new draft release', async() => {
-      githubRepo.getReleaseByTag = sinon.stub().resolves(undefined);
+      const stub = sinon.stub();
+      stub.onFirstCall().resolves(undefined);
+      stub.onSecondCall().resolves({ draft: true });
+      githubRepo.getReleaseByTag = stub;
 
       const params = {
         name: 'release',
@@ -250,7 +253,10 @@ describe('GithubRepo', () => {
     });
 
     it('fails on error', async() => {
-      githubRepo.getReleaseByTag = sinon.stub().resolves(undefined);
+      const stub = sinon.stub();
+      stub.onFirstCall().resolves(undefined);
+      stub.onSecondCall().resolves({ draft: true });
+      githubRepo.getReleaseByTag = stub;
 
       const params = {
         name: 'release',
@@ -268,7 +274,10 @@ describe('GithubRepo', () => {
     });
 
     it('ignores already exists error', async() => {
-      githubRepo.getReleaseByTag = sinon.stub().resolves(undefined);
+      const stub = sinon.stub();
+      stub.onFirstCall().resolves(undefined);
+      stub.onSecondCall().resolves({ draft: true });
+      githubRepo.getReleaseByTag = stub;
 
       const params = {
         name: 'release',
@@ -285,6 +294,31 @@ describe('GithubRepo', () => {
         body: params.notes,
         draft: true,
       });
+    });
+
+    it("fails if release doesn't exist after creating", async() => {
+      process.env.TEST_GET_RELEASE_TIMEOUT = '1000';
+
+      githubRepo.getReleaseByTag = sinon.stub().resolves(undefined);
+
+      const params = {
+        name: 'release',
+        tag: 'v0.8.0',
+        notes: 'notes',
+      };
+
+      try {
+        await githubRepo.updateDraftRelease(params);
+      } catch (e) {
+        return expect(e).to.have.property(
+          'message',
+          "Draft release \"release\" still doesn't exist after creating"
+        );
+      } finally {
+        delete process.env.TEST_GET_RELEASE_TIMEOUT;
+      }
+
+      expect.fail('Expected error');
     });
   });
 


### PR DESCRIPTION
Seems like sometimes on publish we are trying to update newly created release too quickly and github doesn't know that it exists yet (like [here](https://evergreen.mongodb.com/task/10gen_compass_testing_ubuntu_publish_publish_5e1c98432054307a1d5ddccf053dcd79d83be1cd_22_03_30_22_24_10) for example)