### PR TITLE
chore: ignore existing release assets, log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@types/debug": "^4.1.7",
         "debug": "^4.3.4"
       },
       "devDependencies": {
@@ -545,6 +546,14 @@
       "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
       "dev": true
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -577,6 +586,11 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
       "integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
       "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
       "version": "14.17.32",
@@ -7774,6 +7788,14 @@
       "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
       "dev": true
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -7806,6 +7828,11 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
       "integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
       "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
       "version": "14.17.32",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@mongodb-js/devtools-github-repo",
       "version": "1.1.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
       "devDependencies": {
         "@octokit/rest": "^17.9.0",
         "@types/mocha": "^8.0.3",
@@ -1768,11 +1771,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4347,6 +4348,24 @@
         "url": "https://opencollective.com/mochajs"
       }
     },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mocha/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -4383,8 +4402,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multimatch": {
       "version": "5.0.0",
@@ -8683,10 +8701,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -10620,6 +10637,15 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -10646,8 +10672,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multimatch": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "release-it": {},
   "dependencies": {
+    "@types/debug": "^4.1.7",
     "debug": "^4.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "ts-sinon": "^1.2.0",
     "typescript": "^4.0.3"
   },
-  "release-it": {}
+  "release-it": {},
+  "dependencies": {
+    "debug": "^4.3.4"
+  }
 }

--- a/src/github-repo.ts
+++ b/src/github-repo.ts
@@ -4,6 +4,9 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import semver from 'semver/preload';
 import { promisify } from 'util';
+import Debug from 'debug';
+
+const debug = Debug('devtools-github-repo');
 
 type Repo = {
   owner: string;
@@ -228,7 +231,7 @@ export class GithubRepo {
         asset_id: existingAsset.id,
       });
     } else {
-      console.log('could not find the asset in the existing assets', { assetName, existingAssets });
+      debug('could not find the asset in the existing assets %o', { assetName, existingAssets });
     }
 
     const params = {
@@ -242,7 +245,7 @@ export class GithubRepo {
     };
 
     const githubRateLimit = await this.octokit.request('GET /rate_limit', {});
-    console.dir({ githubRateLimit: githubRateLimit?.data }, { depth: Infinity });
+    debug('%o', { githubRateLimit: githubRateLimit?.data });
 
     await this.octokit.request(params)
       // It shouldn't be possible for the asset to already exist due to the check above, but here we are.
@@ -268,7 +271,7 @@ export class GithubRepo {
     }
 
     if (!releaseDetails.draft) {
-      console.info(`Release for ${tag} is already public.`);
+      debug(`Release for ${tag} is already public.`);
       return releaseDetails.html_url;
     }
 

--- a/src/github-repo.ts
+++ b/src/github-repo.ts
@@ -242,7 +242,7 @@ export class GithubRepo {
     };
 
     const githubRateLimit = await this.octokit.request('GET /rate_limit', {});
-    console.dir({ githubRateLimit: githubRateLimit.data }, { depth: Infinity });
+    console.dir({ githubRateLimit: githubRateLimit?.data }, { depth: Infinity });
 
     await this.octokit.request(params)
       // It shouldn't be possible for the asset to already exist due to the check above, but here we are.

--- a/src/github-repo.ts
+++ b/src/github-repo.ts
@@ -6,6 +6,7 @@ import semver from 'semver/preload';
 import { promisify } from 'util';
 import Debug from 'debug';
 
+// eslint-disable-next-line new-cap
 const debug = Debug('devtools-github-repo');
 
 type Repo = {


### PR DESCRIPTION
Uploading assets often fails with a 500 error returned by github. Then we retry and even though there's code to try and delete the asset if it already exists before uploading again we still get the error `✖  Error: RequestError [HttpError]: Validation Failed: {"resource":"ReleaseAsset","code":"already_exists","field":"name"}`.

So this logs what's really in there, logs the rate limit (just in case) and ignores the error if the file already exists.