### PR TITLE
feat: allow to upload multiple assets in one method

### DIFF
--- a/src/github-repo.spec.ts
+++ b/src/github-repo.spec.ts
@@ -369,6 +369,30 @@ describe('GithubRepo', () => {
       });
     });
 
+    it('uploads multiple assets', async() => {
+      const release = {
+        name: 'release',
+        tag: 'v0.8.0',
+        notes: '',
+      };
+      getReleaseByTag.resolves({
+        upload_url: 'url',
+      });
+
+      await githubRepo.uploadReleaseAsset(release.tag, [
+        {
+          path: path.resolve(__dirname, 'github-repo.spec.ts'),
+          contentType: 'xyz',
+        },
+        {
+          path: path.resolve(__dirname, 'github-repo.ts'),
+          contentType: 'xyz',
+        },
+      ]);
+
+      expect(octoRequest).to.have.been.calledTwice;
+    });
+
     it('updates an existing asset by removing the old one first', async() => {
       const release = {
         name: 'release',


### PR DESCRIPTION
Seems like otherwise we can run into [secondary rate limits](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits) trying to pull release details too often for every file